### PR TITLE
Add orchestrator and aggregator endpoints

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,5 +1,7 @@
 from langchain.tools import Tool
 from .classifier import classify
+from .orchestrator import analyze
+from .aggregator import aggregate
 
 # Exponemos el tool para que otros módulos puedan importarlo
 classify_tool = Tool(
@@ -11,4 +13,22 @@ classify_tool = Tool(
     ),
 )
 
-__all__ = ["classify_tool"]
+orchestrator_tool = Tool(
+    name="analyze_document",
+    func=analyze,
+    description=(
+        "Clasifica un RawDocument y, si corresponde, lo divide en sub-documentos. "
+        "Input: ruta del JSON."
+    ),
+)
+
+aggregator_tool = Tool(
+    name="aggregate_documents",
+    func=aggregate,
+    description=(
+        "Agrega metadatos de varios RawDocuments. "
+        "Input: lista de rutas JSON."
+    ),
+)
+
+__all__ = ["classify_tool", "orchestrator_tool", "aggregator_tool"]

--- a/backend/agents/aggregator.py
+++ b/backend/agents/aggregator.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import Any, Dict, List
+
+from backend.schemas.raw_doc import RawDocument
+
+
+def aggregate(json_paths: List[str]) -> Dict[str, Any]:
+    """Return basic metadata for a list of raw documents."""
+    docs = []
+    counts: Dict[str, int] = {}
+    for p in json_paths:
+        raw = RawDocument.model_validate_json(Path(p).read_text(encoding="utf-8"))
+        info = {"id": raw.id, "doc_type": raw.doc_type, "period": raw.period}
+        docs.append(info)
+        counts[raw.doc_type] = counts.get(raw.doc_type, 0) + 1
+    return {"documents": docs, "counts": counts}

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Any, Dict, List
+
+from backend.agents.classifier import classify
+from backend.tools import splitter_tool
+
+
+def analyze(raw_json_path: str | Path) -> Dict[str, Any]:
+    """Classify the document and split if it's a package."""
+    raw_path = Path(raw_json_path)
+    classification = classify(raw_path)
+    children: List[str] = []
+    if classification.get("doc_type") == "paquete_eeff":
+        try:
+            children = splitter_tool.run(str(raw_path))
+        except Exception:
+            children = []
+    return {"classification": classification, "children": children}

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from backend.loaders.ingest import extract_raw_json
-from backend.agents import classify_tool
+from backend.agents import classify_tool, orchestrator_tool, aggregator_tool
 
 
 from backend.tools import splitter_tool
@@ -61,4 +61,24 @@ async def classify(json_path: str):
         result = classify_tool.run(json_path)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Classification error: {e}")
+    return result
+
+
+@app.post("/analyze")
+async def analyze(json_path: str):
+    """Clasifica y divide un documento si es un paquete de EEFF."""
+    try:
+        result = orchestrator_tool.run(json_path)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Analysis error: {e}")
+    return result
+
+
+@app.post("/aggregate")
+async def aggregate(json_paths: list[str]):
+    """Aggrega la información de varios documentos."""
+    try:
+        result = aggregator_tool.run(json_paths)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Aggregation error: {e}")
     return result


### PR DESCRIPTION
## Summary
- add orchestrator and aggregator agents
- expose them via new tools
- create `/analyze` and `/aggregate` API endpoints

## Testing
- `python -m py_compile backend/main.py backend/agents/orchestrator.py backend/agents/aggregator.py backend/agents/__init__.py`
