### PR TITLE
Allow custom tesseract cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ pip install -r requirements.txt
 ```
 OPENAI_API_KEY=your_openai_api_key
 ```
+6. (Optional) Configure the `TESSERACT_CMD` environment variable if the
+   `tesseract` executable is not in your `PATH`:
+```bash
+export TESSERACT_CMD=/usr/bin/tesseract  # adjust to your installation
+```
 
 ## Usage
 

--- a/backend/loaders/ocr_pdf.py
+++ b/backend/loaders/ocr_pdf.py
@@ -6,14 +6,16 @@ Usa PyMuPDF (fitz) para rasterizar páginas a PNG y pytesseract para OCR.
 
 from pathlib import Path
 from typing import List
+import os
 import fitz  # PyMuPDF
 import pytesseract
 from PIL import Image
 from langchain_core.documents import Document
 import io
 # backend/loaders/ocr_pdf.py
-import pytesseract
-pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+
+# Configure tesseract command
+pytesseract.pytesseract.tesseract_cmd = os.getenv("TESSERACT_CMD", "tesseract")
 
 
 


### PR DESCRIPTION
## Summary
- deduplicate pytesseract import
- allow configuring tesseract path via `TESSERACT_CMD`
- document the new variable in the README

## Testing
- `python -m py_compile backend/loaders/ocr_pdf.py`